### PR TITLE
Fix #1243 - Chrome displaying blank time picker

### DIFF
--- a/lib/themes/classic.time.css
+++ b/lib/themes/classic.time.css
@@ -117,6 +117,7 @@
  */
 .picker--time .picker__holder {
   background: #f2f2f2;
+  transform: translate(-1em, 50%);
 }
 @media (min-height: 40.125em) {
   .picker--time .picker__holder {


### PR DESCRIPTION
Fixing #1243 as proposed in the comments